### PR TITLE
Compile with allenai-sbt-plugins.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+target/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-.idea/
 target/

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,31 @@
-name := "openie"
+import org.allenai.plugins.CoreDependencies
 
-organization := "edu.washington.cs.knowitall.openie"
+lazy val buildSettings = Seq(
+  organization := "org.allenai.openie",
+  crossScalaVersions := Seq(CoreDependencies.defaultScalaVersion),
+  scalaVersion <<= crossScalaVersions { (vs: Seq[String]) => vs.head },
+  publishMavenStyle := true,
+  publishArtifact in Test := false,
+  pomIncludeRepository := { _ => false },
+  licenses += ("Open IE Software License Agreement", url("https://raw.github.com/knowitall/openie/master/LICENSE")),
+  homepage := Some(url("https://github.com/allenai/openie")),
+  scmInfo := Some(ScmInfo(
+    url("https://github.com/allenai/openie-standalone"),
+    "https://github.com/allenai/openie-standalone.git")),
+  pomExtra := (
+    <developers>
+      <developer>
+        <id>allenai-dev-role</id>
+        <name>Allen Institute for Artificial Intelligence</name>
+        <email>dev-role@allenai.org</email>
+      </developer>
+    </developers>),
+  bintrayPackage := s"${organization.value}:${name.value}_${scalaBinaryVersion.value}"
+)
 
-crossScalaVersions := Seq("2.11.8")
-
-scalaVersion <<= crossScalaVersions { (vs: Seq[String]) => vs.head }
-
-resolvers += "Sonatype SNAPSHOTS" at "https://oss.sonatype.org/content/repositories/snapshots/"
+lazy val openie = Project(id = "openie", base = file("."))
+  .settings(buildSettings)
+  .enablePlugins(LibraryPlugin)
 
 libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.0.13",
@@ -35,8 +54,6 @@ libraryDependencies ++= Seq(
 
 scalacOptions ++= Seq("-unchecked", "-deprecation")
 
-// custom options for high memory usage
-
 javaOptions += "-Xmx4G"
 
 javaOptions += "-XX:+UseConcMarkSweepGC"
@@ -45,35 +62,5 @@ fork in run := true
 
 fork in Test := true
 
-connectInput in run := true // forward stdin/out to fork
-
-licenses := Seq("Open IE Software License Agreement" -> url("https://raw.github.com/knowitall/openie/master/LICENSE"))
-
-homepage := Some(url("https://github.com/knowitall/openie"))
-
-publishMavenStyle := true
-
-publishTo <<= version { (v: String) =>
-  val nexus = "https://oss.sonatype.org/"
-  if (v.trim.endsWith("SNAPSHOT"))
-    Some("snapshots" at nexus + "content/repositories/snapshots")
-  else
-    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
-}
-
-pomExtra := (
-  <scm>
-    <url>https://github.com/knowitall/openie</url>
-    <connection>scm:git://github.com/knowitall/openie.git</connection>
-    <developerConnection>scm:git:git@github.com:knowitall/openie.git</developerConnection>
-    <tag>HEAD</tag>
-  </scm>
-  <developers>
-   <developer>
-      <name>Michael Schmitz</name>
-    </developer>
-    <developer>
-      <name>Bhadra Mani</name>
-    </developer>
-  </developers>)
-
+// forward stdin/out to fork, so the OpenIE CLI can be run in sbt.
+connectInput in run := true

--- a/build.sbt
+++ b/build.sbt
@@ -6,14 +6,19 @@ lazy val buildSettings = Seq(
   scalaVersion <<= crossScalaVersions { (vs: Seq[String]) => vs.head },
   publishMavenStyle := true,
   publishArtifact in Test := false,
-  pomIncludeRepository := { _ => false },
-  licenses += ("Open IE Software License Agreement", url("https://raw.github.com/knowitall/openie/master/LICENSE")),
-  homepage := Some(url("https://github.com/allenai/openie")),
+  licenses += ("Open IE Software License Agreement", url("https://raw.githubusercontent.com/allenai/openie-standalone/master/LICENSE")),
+  homepage := Some(url("https://github.com/allenai/openie-standalone")),
   scmInfo := Some(ScmInfo(
     url("https://github.com/allenai/openie-standalone"),
     "https://github.com/allenai/openie-standalone.git")),
   pomExtra := (
     <developers>
+      <developer>
+        <name>Michael Schmitz</name>
+      </developer>
+      <developer>
+        <name>Bhadra Mani</name>
+      </developer>
       <developer>
         <id>allenai-dev-role</id>
         <name>Allen Institute for Artificial Intelligence</name>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.allenai.plugins" % "allenai-sbt-plugins" % "1.2.5")


### PR DESCRIPTION
This change makes artifacts with groupId = `org.allenai.openie`, artifactId = `openie` and version = `4.2.2-SNAPSHOT` (same as the latest version from UW).

Tested with `publishLocal`, saw files appear in `~/.ivy2/local/org.allenai.openie`. Then I made it a dependency in aristo/'s `controller/build.sbt` with this:

```
libraryDependencies ++= Seq(
  ...,
  "org.allenai.openie" %% "openie" % "4.2.2-SNAPSHOT"
)
```

and it compiled, warning `[warn] Choosing local for org.allenai.openie#openie_2.11;4.2.2-SNAPSHOT`.

I haven't tried to publish non-locally (i.e., to bintray). If this change looks good to you can I try that. (I'm not sure yet how to see the contents of bintray before/after to confirm it worked.)
