### PR TITLE
Forcing bintray to ignore license checks.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ lazy val buildSettings = Seq(
       </developer>
     </developers>),
   bintrayPackage := s"${organization.value}:${name.value}_${scalaBinaryVersion.value}",
-  bintrayEnsureLicenses := {}
+  bintrayOmitLicense := true
 )
 
 lazy val openie = Project(id = "openie", base = file("."))

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,15 @@ lazy val buildSettings = Seq(
       </developer>
     </developers>),
   bintrayPackage := s"${organization.value}:${name.value}_${scalaBinaryVersion.value}",
+
+  // Bintray supports specific OSS licenses:
+  //
+  //     https://bintray.com/docs/api/#_footnote_1
+  //
+  // OpenIE's license is unsupported by Bintray, which means it cannot be
+  // published there publicly. Here we ask Bintray to bypass the license
+  // restriction check during publication because we intend to publish
+  // privately.
   bintrayOmitLicense := true
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,8 @@ lazy val buildSettings = Seq(
         <email>dev-role@allenai.org</email>
       </developer>
     </developers>),
-  bintrayPackage := s"${organization.value}:${name.value}_${scalaBinaryVersion.value}"
+  bintrayPackage := s"${organization.value}:${name.value}_${scalaBinaryVersion.value}",
+  bintrayEnsureLicenses := {}
 )
 
 lazy val openie = Project(id = "openie", base = file("."))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.2.3-SNAPSHOT"
+version in ThisBuild := "4.2.3"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "4.2.3"
+version in ThisBuild := "4.2.4-SNAPSHOT"


### PR DESCRIPTION
`sbt publish` as executed in semaphoreci fails like this:

```
[error] (*:bintrayEnsureLicenses) One or more of the defined licenses were not among the following allowed licenses ...
```

See https://semaphoreci.com/allenai/openie-standalone/branches/master/builds/6

So I'm following this change: https://github.com/allenai/datastore/commit/e1cce1db64897d51c28aeee123c3ca51184c356f#diff-fdc3abdfd754eeb24090dbd90aeec2ce

...although this was undone eventually: https://github.com/allenai/datastore/commit/760926d8c25a21af90d159103030c5c7c45e9467#diff-fdc3abdfd754eeb24090dbd90aeec2ce

Hoping this has the effect of letting `sbt publish` complete its work.
