### PR TITLE
Fix spelling of output in CLI options

### DIFF
--- a/src/main/scala/edu/knowitall/chunkedextractor/Relnoun.scala
+++ b/src/main/scala/edu/knowitall/chunkedextractor/Relnoun.scala
@@ -739,6 +739,10 @@ object Relnoun {
       opt[String]("ouput-file") action { (string, config) =>
         val file = new File(string)
         config.copy(outputFile = Some(file))
+      } text ("output file (deprecated)")
+      opt[String]("output-file") action { (string, config) =>
+        val file = new File(string)
+        config.copy(outputFile = Some(file))
       } text ("output file")
       opt[String]("encoding") action { (string, config) =>
         config.copy(encoding = string)

--- a/src/main/scala/edu/knowitall/openie/OpenIECli.scala
+++ b/src/main/scala/edu/knowitall/openie/OpenIECli.scala
@@ -131,6 +131,10 @@ object OpenIECli extends App {
     opt[String]("ouput-file") action { (string, config) =>
       val file = new File(string)
       config.copy(outputFile = Some(file))
+    } text ("output file (deprecated)")
+    opt[String]("output-file") action { (string, config) =>
+      val file = new File(string)
+      config.copy(outputFile = Some(file))
     } text ("output file")
     opt[String]("parser-server") action { (string, config) =>
       config.copy(parserServer = Some(new URL(string)))

--- a/src/main/scala/edu/knowitall/srlie/SrlExtractor.scala
+++ b/src/main/scala/edu/knowitall/srlie/SrlExtractor.scala
@@ -80,6 +80,10 @@ object SrlExtractor extends App {
     opt[String]("ouput file") action { (string, config) =>
       val file = new File(string)
       config.copy(outputFile = Some(file))
+    } text ("output file (deprecated)")
+    opt[String]("output file") action { (string, config) =>
+      val file = new File(string)
+      config.copy(outputFile = Some(file))
     } text ("output file")
     opt[String]("gold") action { (string, config) =>
       val file = new File(string)


### PR DESCRIPTION
The output file option for the OpenIE CLI is confusingly named "ouput file". I've changed this to correct the spelling. I have retained the old option with a deprecated explanation in the CLI usage instructions.